### PR TITLE
Fix partial move error

### DIFF
--- a/src/persist.rs
+++ b/src/persist.rs
@@ -51,7 +51,7 @@ pub fn update_transactions(new_transactions: Vec<Transaction>) {
 
     // Add new transactions
     for nt in new_transactions.into_iter() {
-        current_transactions.insert(nt.uid, nt);
+        current_transactions.insert(nt.uid.clone(), nt);
     }
 
     // Save updated transactions


### PR DESCRIPTION
If you were to move `nt.uid` into the Hashmap key and then _also_ move `nt` into the value, then the key and the value would both point to the same string. The solution is to clone the uid for the key, meaning it doesn't point to the string in the nt.

```
error[E0382]: use of partially moved value: `nt`
  --> src/persist.rs:54:45
   |
54 |         current_transactions.insert(nt.uid, nt);
   |                                     ------  ^^ value used here after partial move
   |                                     |
   |                                     value partially moved here
   |
   = note: partial move occurs because `nt.uid` has type `std::string::String`, which does not implement the `Copy` trait
```

This is called a partial move, meaning a part of the `nt` struct has been taken, so you cannot use it in its entirety. You can however move _different_ fields of the struct, and move each field at most one time.